### PR TITLE
Ensure messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ for i in 0..5 {
     // ensure! will only trigger the debugger once
     // when the expression argument is false
     unbug::ensure!(false);
+    unbug::ensure!(false, "Ensure can take an optional log message");
+    unbug::ensure!(false, "{}", i);
 
     // ensure_always! will trigger the debugger every time
     // when the expression argument is false

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,17 +1,17 @@
 #![cfg_attr(
-    all(
-        debug_assertions,
-        feature = "dev_debug",
-    ),
+    all(debug_assertions, feature = "dev_debug",),
     feature(core_intrinsics),
-    allow(internal_features),
+    allow(internal_features)
 )]
 
 use unbug::prelude::*;
 
 fn try_some_option(in_opt: Option<()>) {
     let Some(_out_var) = in_opt else {
-        fail_always!("fail_always! can also be formatted - in_opt was: {:?}", in_opt);
+        fail_always!(
+            "fail_always! can also be formatted - in_opt was: {:?}",
+            in_opt
+        );
         return;
     };
 }
@@ -23,6 +23,7 @@ fn main() {
 
     for i in 0..5 {
         ensure!(false);
+        ensure!(false, "ensure messages can be logged during development");
         ensure_always!(i % 2 == 0);
 
         fail!("fail! will happen only once");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ macro_rules! breakpoint {
 
 /// When enabled, will pause execution with a break point when expression is false
 ///
+/// Can optionally log error messages when the tracing crate is used
+///
 /// Will break on every execution
 ///
 /// Requires Nightly Rust
@@ -63,7 +65,7 @@ macro_rules! breakpoint {
 #[macro_export]
 #[cfg(not(all(debug_assertions, feature = "enable")))]
 macro_rules! ensure_always {
-    ($expression: expr) => {};
+    ($($argument: tt),+ $(,)?) => {};
 }
 #[macro_export]
 #[cfg(all(debug_assertions, feature = "enable"))]
@@ -73,11 +75,19 @@ macro_rules! ensure_always {
             $crate::breakpoint!();
         }
     };
+    ($expression: expr, $($argument: tt),+ $(,)?) => {
+        if !$expression {
+            $crate::_internal::_error!($($argument),+);
+            $crate::breakpoint!();
+        }
+    };
 }
 
 /// When enabled, will pause execution with a break point when expression is false
 ///
 /// Will only break once per program run
+///
+/// Can optionally log error messages when the tracing crate is used
 ///
 /// Requires Nightly Rust
 ///
@@ -85,17 +95,18 @@ macro_rules! ensure_always {
 ///
 /// ```rust
 /// unbug::ensure!(false);
+/// unbug::ensure!(false, "some message to log before breaking");
 /// ```
 #[macro_export]
 #[cfg(not(all(debug_assertions, feature = "enable")))]
 macro_rules! ensure {
-    ($expression: expr) => {};
+    ($($argument: tt),+ $(,)?) => {};
 }
 #[macro_export]
 #[cfg(all(debug_assertions, feature = "enable"))]
 macro_rules! ensure {
-    ($expression: expr) => {
-        $crate::_internal::_once!($crate::ensure_always!($expression))
+    ($($argument: tt),+ $(,)?) => {
+        $crate::_internal::_once!($crate::ensure_always!($($argument),+))
     };
 }
 


### PR DESCRIPTION
Added an optional argument for log messages to ensure and updated documentation. Unlike the `fail!` macro, these messages will not be included in a production build.