### PR TITLE
Support stable Rust and consistent debugging statements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,46 @@ macro_rules! breakpoint {
     () => {};
 }
 #[macro_export]
-#[cfg(all(debug_assertions, feature = "enable"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    debug_assertions,
+    feature = "enable"
+))]
 macro_rules! breakpoint {
     () => {
         unsafe {
-            std::intrinsics::breakpoint();
+            ::core::arch::asm!("int3;nop");
+        }
+    };
+}
+#[macro_export]
+#[cfg(all(
+    any(target_arch = "arm", target_arch = "aarch64"),
+    debug_assertions,
+    feature = "enable"
+))]
+macro_rules! breakpoint {
+    () => {
+        unsafe {
+            ::core::arch::asm!("brk #1");
+        }
+    };
+}
+#[macro_export]
+#[cfg(all(
+    not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+    )),
+    debug_assertions,
+    feature = "enable"
+))]
+macro_rules! breakpoint {
+    () => {
+        unsafe {
+            ::std::intrinsics::breakpoint();
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,14 +54,14 @@ macro_rules! breakpoint {
 }
 #[macro_export]
 #[cfg(all(
-    any(target_arch = "arm", target_arch = "aarch64"),
+    target_arch = "aarch64",
     debug_assertions,
     feature = "enable"
 ))]
 macro_rules! breakpoint {
     () => {
         unsafe {
-            ::core::arch::asm!("brk #1");
+            ::core::arch::asm!("brk#0xF000\nnop");
         }
     };
 }
@@ -70,7 +70,6 @@ macro_rules! breakpoint {
     not(any(
         target_arch = "x86",
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
     )),
     debug_assertions,


### PR DESCRIPTION
This will not support Stable Rust on all platforms, just x86, x86_64, and ARM64.

This update was inspired by [this Hacker News thread](https://news.ycombinator.com/item?id=42194057)