### PR TITLE
Debugger presence detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,7 @@
                 "args": [
                     "build",
                     "--bin=unbug_basic_example",
-                    "--package=unbug_basic_example",
-                    "--features=dev_debug"
+                    "--package=unbug_basic_example"
                 ],
                 "filter": {
                     "name": "unbug_basic_example",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,8 +6,7 @@
             "command": "build",
             "args": [
                 "--bin=unbug_basic_example",
-                "--package=unbug_basic_example",
-                "--features=dev_debug"
+                "--package=unbug_basic_example"
             ],
             "problemMatcher": [
                 "$rustc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "dbg_breakpoint"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca1d6cf3935471325592d19c60c6b44d4efdbf69b85a7adec7342423975ca86"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.166"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "log"
@@ -163,6 +178,7 @@ dependencies = [
 name = "unbug"
 version = "0.3.0"
 dependencies = [
+ "dbg_breakpoint",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "dbg_breakpoint"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca1d6cf3935471325592d19c60c6b44d4efdbf69b85a7adec7342423975ca86"
+checksum = "fb333c8dc699012c0694fe7c7eca7d625f2bceeeef44fd1de39008d6a6abf777"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,19 @@ documentation = "https://docs.rs/unbug"
 license = "MIT OR Apache-2.0"
 keywords = ["debug", "debugging", "ensure", "assert", "breakpoint"]
 authors = [
-  "Brian Jesse <brian@greymattergames.net>",
-  "Scott Girton <scott@greymattergames.net>"
+    "Brian Jesse <brian@greymattergames.net>",
+    "Scott Girton <scott@greymattergames.net>",
 ]
 categories = ["development-tools::debugging"]
 exclude = [".vscode/", "assets/"]
 
 [dependencies]
 tracing = "0.1"
-dbg_breakpoint = "0.1.0"
+dbg_breakpoint = "0.1.1"
+
+[features]
+default = []
+no_cache_debugger = []
 
 [[example]]
 name = "basic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,14 @@ license = "MIT OR Apache-2.0"
 keywords = ["debug", "debugging", "ensure", "assert", "breakpoint"]
 authors = [
   "Brian Jesse <brian@greymattergames.net>",
+  "Scott Girton <scott@greymattergames.net>"
 ]
 categories = ["development-tools::debugging"]
 exclude = [".vscode/", "assets/"]
 
-[features]
-default = []
-enable = []
-
 [dependencies]
 tracing = "0.1"
+dbg_breakpoint = "0.1.0"
 
 [[example]]
 name = "basic"

--- a/examples/basic/.vscode/launch.json
+++ b/examples/basic/.vscode/launch.json
@@ -9,8 +9,7 @@
                 "args": [
                     "build",
                     "--bin=unbug_basic_example",
-                    "--package=unbug_basic_example",
-                    "--features=dev_debug"
+                    "--package=unbug_basic_example"
                 ],
                 "filter": {
                     "name": "unbug_basic_example",

--- a/examples/basic/.vscode/tasks.json
+++ b/examples/basic/.vscode/tasks.json
@@ -6,8 +6,7 @@
             "command": "build",
             "args": [
                 "--bin=unbug_basic_example",
-                "--package=unbug_basic_example",
-                "--features=dev_debug"
+                "--package=unbug_basic_example"
             ],
             "problemMatcher": [
                 "$rustc"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -4,12 +4,6 @@ version = "1.0.0"
 edition = "2021"
 publish = false
 
-[features]
-default = []
-dev_debug = [
-    "unbug/enable"
-]
-
 [dependencies]
 unbug = { path = "../../" }
 tracing-subscriber = "0.3"


### PR DESCRIPTION
This adds the ability to check for debuggers using the functionality from the [dbg_breakpoint](https://github.com/kromych/dbg_breakpoint) crate.

That crate doesn't have any ecosystem usage currently, but it comes from a PR that was [merged into Rust](https://github.com/rust-lang/rust/pull/129019) and then [reverted later](https://github.com/rust-lang/rust/pull/130846).

I've audited the crate source and pinned the `0.1.1` version to avoid any possible supply-chain attacks since the crate is so small and new.

Additionally I added a cache for the debugger presence result and added a feature `no_cache_debugger` to skip the cache.